### PR TITLE
Fix interest calculation for Premium Jar after penalty

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,14 @@ env:
 
 jobs:
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Lint
+        run: make lint
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -27,16 +35,7 @@ jobs:
           name: sweat-jar
           path: res/sweat_jar.wasm
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Lint
-        run: make lint
-
   unit-tests:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +44,6 @@ jobs:
         run: make test
 
   integration-tests:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,7 +53,6 @@ jobs:
         run: make integration
 
   mutation-tests:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - name: Install tool
@@ -68,7 +65,6 @@ jobs:
         run: make mutation
 
   measure:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -84,7 +80,7 @@ jobs:
           path: measured.txt
 
   push:
-    needs: [ unit-tests, integration-tests, measure, mutation-tests ]
+    needs: [ build, lint, unit-tests, integration-tests, measure, mutation-tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,14 @@ env:
 
 jobs:
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Lint
+        run: make lint
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -17,14 +25,6 @@ jobs:
 
       - name: Build
         run: make build
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Lint
-        run: make lint
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
         run: make lint
 
   unit-tests:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +35,6 @@ jobs:
         run: make test
 
   integration-tests:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,7 +44,6 @@ jobs:
         run: make integration
 
   mutation-tests:
-    needs: [ build, lint ]
     runs-on: ubuntu-latest
     steps:
       - name: Install tool

--- a/contract/src/jar/model.rs
+++ b/contract/src/jar/model.rs
@@ -127,7 +127,13 @@ impl Jar {
         self.is_pending_withdraw = false;
     }
 
-    pub(crate) fn apply_penalty(&mut self, is_applied: bool) {
+    pub(crate) fn apply_penalty(&mut self, product: &Product, is_applied: bool, now: Timestamp) {
+        let current_interest = self.get_interest(product, now);
+
+        self.cache = Some(JarCache {
+            updated_at: now,
+            interest: current_interest,
+        });
         self.is_penalty_applied = is_applied;
     }
 

--- a/contract/src/penalty/api.rs
+++ b/contract/src/penalty/api.rs
@@ -33,10 +33,13 @@ impl PenaltyApi for Contract {
 
         let jar_id = jar_id.0;
         let jar = self.get_jar_internal(&account_id, jar_id);
-        let product = self.get_product(&jar.product_id);
+        let product = self.get_product(&jar.product_id).clone();
+        let now = env::block_timestamp_ms();
 
         match product.apy {
-            Apy::Downgradable(_) => self.get_jar_mut_internal(&account_id, jar_id).apply_penalty(value),
+            Apy::Downgradable(_) => self
+                .get_jar_mut_internal(&account_id, jar_id)
+                .apply_penalty(&product, value, now),
             Apy::Constant(_) => env::panic_str("Penalty is not applicable for constant APY"),
         };
 

--- a/contract/src/tests.rs
+++ b/contract/src/tests.rs
@@ -243,18 +243,55 @@ fn get_total_interest_for_premium_with_penalty_after_half_term() {
         .with_products(&[reference_product])
         .with_jars(&[reference_jar]);
 
-    context.set_block_timestamp_in_days(182);
+    context.set_block_timestamp_in_ms(15_768_000_000);
 
     let mut interest = context.contract.get_total_interest(alice.clone()).amount.total.0;
-    assert_eq!(interest, 9_972_602);
+    assert_eq!(interest, 10_000_000);
 
     context.switch_account(&admin);
     context.contract.set_penalty(alice.clone(), U32(0), true);
 
-    context.set_block_timestamp_in_days(365);
+    context.set_block_timestamp_in_ms(31_536_000_000);
 
     interest = context.contract.get_total_interest(alice).amount.total.0;
-    assert_eq!(interest, 10_000_000);
+    assert_eq!(interest, 15_000_000);
+}
+
+#[test]
+fn get_total_interest_for_premium_with_multiple_penalties_applied() {
+    let alice = accounts(0);
+    let admin = accounts(1);
+
+    let signer = MessageSigner::new();
+    let reference_product = Product::generate("lux_product")
+        .enabled(true)
+        .apy(Apy::Downgradable(DowngradableApy {
+            default: UDecimal::new(23, 2),
+            fallback: UDecimal::new(10, 2),
+        }))
+        .lockup_term(3_600_000)
+        .public_key(signer.public_key());
+    let reference_jar = Jar::generate(0, &alice, &reference_product.id).principal(100_000_000_000_000_000_000_000);
+
+    let mut context = Context::new(admin.clone())
+        .with_products(&[reference_product])
+        .with_jars(&[reference_jar]);
+
+    context.switch_account(&admin);
+
+    context.set_block_timestamp_in_ms(270_000);
+    context.contract.set_penalty(alice.clone(), U32(0), true);
+
+    context.set_block_timestamp_in_ms(390_000);
+    context.contract.set_penalty(alice.clone(), U32(0), false);
+
+    context.set_block_timestamp_in_ms(1_264_000);
+    context.contract.set_penalty(alice.clone(), U32(0), true);
+
+    context.set_block_timestamp_in_ms(3_700_000);
+
+    let interest = context.contract.get_total_interest(alice.clone()).amount.total.0;
+    assert_eq!(interest, 1_613_140_537_798_072_042);
 }
 
 #[test]


### PR DESCRIPTION
### Problem

When an Oracle applied penalty to a Premium Jar, it affected only `is_penalty_applied` property of the Jar, but not the interest calculation.

### Solution

Now applying a penalty updates `cache` of the Jar, so interest calculation takes into account all the APY changes.