### PR TITLE
fix: set timezone on restake into score based product

### DIFF
--- a/contract/src/feature/account/tests/restake_all.rs
+++ b/contract/src/feature/account/tests/restake_all.rs
@@ -1,13 +1,13 @@
 use near_sdk::{test_utils::test_env::alice, AccountId};
 use rstest::rstest;
 use sweat_jar_model::{
-    api::{ProductApi, RestakeApi},
+    api::{ClaimApi, ProductApi, RestakeApi},
     data::{
         deposit::{DepositMessage, DepositTicket, Purpose},
         jar::Jar,
         product::{Product, ProductModelApi},
     },
-    MS_IN_DAY, MS_IN_YEAR,
+    Timezone, MS_IN_DAY, MS_IN_YEAR,
 };
 
 use crate::{
@@ -341,4 +341,32 @@ fn restake_all_for_multiple_products_with_withdrawal_and_fee(
     assert_eq!(data.restaked.0, principal - withdrawal_amount);
     assert_eq!(data.withdrawn.0, withdrawal_amount - target_fee);
     assert_eq!(context.contract().fee_amount, target_fee);
+}
+
+#[rstest]
+fn claim_after_restake_all_into_first_score_based_jar(
+    admin: AccountId,
+    alice: AccountId,
+    #[from(product_1_year_apy_20_percent)] fixed_product: Product,
+    #[from(product_1_year_12_cap_score_based)] score_based_product: Product,
+    #[with(vec![(0, 100_000), (MS_IN_YEAR / 4, 100_000)])] jar: Jar,
+) {
+    let mut context = Context::new(admin)
+        .with_products(&[fixed_product.clone(), score_based_product.clone()])
+        .with_jars(&alice, &[(fixed_product.id.clone(), jar.clone())]);
+
+    let test_time = MS_IN_YEAR * 2;
+    context.set_block_timestamp_in_ms(test_time);
+
+    context.switch_account(alice.clone());
+    let valid_until = MS_IN_YEAR * 10;
+    let ticket = DepositTicket {
+        product_id: score_based_product.id.clone(),
+        valid_until: valid_until.into(),
+        timezone: Some(Timezone::new(0)),
+    };
+    context.contract().restake_all(ticket, None, None);
+
+    let claim_amount = context.claim_total(&alice);
+    assert_eq!(40_000, claim_amount);
 }

--- a/contract/src/feature/restake/api/api.rs
+++ b/contract/src/feature/restake/api/api.rs
@@ -9,7 +9,7 @@ use sweat_jar_model::{
     data::{
         deposit::{DepositTicket, Purpose},
         jar::Assertions,
-        product::{ProductAssertions, ProductId, ProductModelApi},
+        product::{ProductAssertions, ProductId, ProductModelApi, Terms},
     },
     TokenAmount,
 };
@@ -125,6 +125,12 @@ impl Contract {
 
         for (product_id, _) in &request.partitions {
             self.update_jar_cache(&request.account_id, product_id);
+        }
+
+        let product = self.get_product(&ticket.product_id);
+        if matches!(product.terms, Terms::ScoreBased(_)) {
+            self.get_account_mut(&request.account_id)
+                .try_set_timezone(ticket.timezone);
         }
 
         if request.withdrawal.is_none() {

--- a/model/src/data/account/v1.rs
+++ b/model/src/data/account/v1.rs
@@ -57,15 +57,14 @@ impl AccountV1 {
     }
 
     pub fn try_set_timezone(&mut self, timezone: Option<Timezone>) {
-        match (timezone, self.score.is_valid()) {
-            // Time zone already set. No actions required.
-            (Some(_) | None, true) => (),
-            (Some(timezone), false) => {
-                self.score = AccountScore::new(timezone);
-            }
-            (None, false) => {
-                panic_str("Trying to create score based jar without providing time zone");
-            }
+        if self.score.is_timezone_set() {
+            return;
+        }
+
+        if let Some(timezone) = timezone {
+            self.score = AccountScore::new(timezone);
+        } else {
+            panic_str("Trying to create score based jar without providing time zone");
         }
     }
 
@@ -97,6 +96,6 @@ impl AccountV1 {
     }
 
     pub fn has_score_jars(&self) -> bool {
-        self.score.is_valid()
+        self.score.is_timezone_set()
     }
 }

--- a/model/src/data/score/common.rs
+++ b/model/src/data/score/common.rs
@@ -4,7 +4,7 @@ use super::DAYS_STORED;
 use crate::{AccountScore, Chain, Day, Local, Score, ScoreRecord, TimeHelper, Timezone};
 
 impl AccountScore {
-    pub fn is_valid(&self) -> bool {
+    pub fn is_timezone_set(&self) -> bool {
         self.timezone.is_valid()
     }
 
@@ -48,7 +48,7 @@ impl AccountScore {
     }
 
     pub fn try_reset_score(&mut self) {
-        if self.is_valid() {
+        if self.is_timezone_set() {
             self.reset_score();
         }
     }

--- a/model/src/types/timezone.rs
+++ b/model/src/types/timezone.rs
@@ -14,6 +14,10 @@ use crate::{Day, Local, TimeHelper, MS_IN_HOUR, UTC};
 pub struct Timezone(i64);
 
 impl Timezone {
+    pub const fn new(timezone: i64) -> Self {
+        Self(timezone)
+    }
+
     pub const fn invalid() -> Self {
         Self(i64::MIN)
     }


### PR DESCRIPTION
Try setting timezone on restaking into score based products to prevent errors like this:
https://nearblocks.io/ru/txns/9m56rPBTVYMhrxpucknWkBXqC9z2c91WzHZ88sEJvpin?tab=execution

This kind of errors occurs when a user had never created score based jars before restaking.